### PR TITLE
Removing a mistyped variable from comments.

### DIFF
--- a/FindGlog.cmake
+++ b/FindGlog.cmake
@@ -8,7 +8,6 @@
 #  GLOG_FOUND
 #  GLOG_INCLUDE_DIRS
 #  GLOG_LIBRARIES
-#  GLOG_LIBRARYRARY_DIRS
 
 include(FindPackageHandleStandardArgs)
 


### PR DESCRIPTION
This variable isn't actually getting populated, the other two are.
